### PR TITLE
[KAN-48] tailwind 폰트, 반응형 브레이크포인트 설정

### DIFF
--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -68,6 +68,7 @@ const theme: MantineThemeOverride = {
       "#FDD181",
     ],
   },
+  fontFamily: "Pretendard, sans-serif",
 };
 // note  mantine theme 색상 배열타입 기본 길이가 10으로 설정되어 있어서 사용하는 색상 외에는 임의로 채워넣었습니다..
 // theme.colors.gray[0]

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,10 @@
 import { createTheme, MantineThemeOverride } from "@mantine/core";
 
 const theme: MantineThemeOverride = {
+  breakpoints: {
+    sm: "744px",
+    lg: "1200px",
+  },
   colors: {
     gray: [
       "#F7F7FA",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,6 +4,12 @@ const config: Config = {
   content: ["./pages/**/*.{js,ts,jsx,tsx,mdx}", "./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {
+      screens: {
+        md: "744px",
+        // => @media (min-width: 744px) { ... }
+        xl: "1200px",
+        // => @media (min-width: 1280px) { ... }
+      },
       height: {
         "400": "400px",
       },


### PR DESCRIPTION
## :bookmark: Issue Ticket
<!-- Issue Ticket이 있을 경우, 해당 링크를 연결해주세요 -->
https://2youlrang.atlassian.net/browse/KAN-48

## :writing_hand: Description
<!-- 어떤 내용의 PR인지 간단하게 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->

develop 브랜치에 바로 머지하여 작업의 편의성을 높이고자 합니다

- 테마 폰트 설정하여 body에 `Pretendard` 폰트 적용되도록 했습니다.
- 반응형 브레이크 포인트 설정입니다.
 mantain : `sm: "744px", lg: "1200px"`
 tailwind : `md: "744px", xl: "1200px"`

예)
mantain에서 `<Box w={{base:300, sm:400, lg: 500}}>`
tailwind에서 `<div className="w-[300px] md:w-[400px] xl:w-[500px]">`


## :white_check_mark: Checklist
### PR
<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->
- [x] Branch Convention 확인
> `epic/` 에픽, `feat/` 피쳐, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test
- [x] 로컬 작동 확인

### Additional Notes
<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->
- [ ] (없음)
